### PR TITLE
Bump `chrono` and remove the dependency on `time`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 include = ["src/**/*", "Cargo.toml", "README.md", "LICENSE"]
 
 [dependencies]
-chrono = "0.4.4"
+chrono = { version = "0.4.24", default-features = false, features = ["clock"] }
 regex = "1.0.5"
 xz2 = "0.1.5"
 path-absolutize = "3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ use std::{
     time::Duration,
 };
 
-use chrono::prelude::*;
+use chrono::{DateTime, Utc};
 use path_absolutize::*;
 use regex::Regex;
 pub use rotate_method::RotateMethod;


### PR DESCRIPTION
`chrono` still uses `time 0.1` (it's at 0.3.22 now) because they are dropping it in the upcoming 0.5 breaking release. Until then, `time` is included behind an enabled-by-default feature flag, which this project doesn't require. Dropping the dependency means the old `time` version is not pulled in and doesn't have to be built by users of `pipe-logger-lib`.